### PR TITLE
Updates to the Simulations table

### DIFF
--- a/Manuscript/LIPIDionINTERACT.tex
+++ b/Manuscript/LIPIDionINTERACT.tex
@@ -481,7 +481,8 @@ from overbinding of ions or from too sensitive lipid headgroup response on bound
 (see also discussion in ESI$^\dag$). 
 A careful analysis with current lipid models is performed in the next section.
 
-\begin{sidewaystable*}[!p]
+%\begin{sidewaystable*}[!p]
+\begin{table*}[!p]
 \centering
 \caption{List of simulations performed in this work. The ion concentrations are calculated as 
    [ion]=(N$_{\rm ion} \times$[water])/N$_{\rm w}$, where [water]=55.5M. 
@@ -506,6 +507,7 @@ A careful analysis with current lipid models is performed in the next section.
   BergerOPLS-DPPC-06\cite{tieleman06}, OPLS\cite{aqvist90} &   DPPC & 1000 (NaCl) & 72 & 2778 & 51  & 0  & 51 &323  & 120 & 60 &\citenum{bergerOPLSDPPCfiles1000mMnacl} \\
   \hline
   CHARMM36\cite{klauda10}   & POPC & 0           & 72 & 2242 & 0  & 0 & 0 & 303  & 30 & 20 & \citenum{charmm36filesSHORT} \\
+  CHARMM36\cite{klauda10} & POPC & 0 & 128 & 5210 & 0 & 0 & 0 & 303 & 200 & 150 & \citenum{charmm36files} \\ % Hubert's 0CHL simu (doi: 10.5281/zenodo.14066)
   CHARMM36\cite{klauda10}, CHARMM36\cite{venable13} & POPC & 350 (NaCl)  & 72 & 2085 & 13  & 0 & 13 & 303  & 80 & 60 & \citenum{charmmPOPC350mMNaClfiles} \\
   CHARMM36\cite{klauda10}, CHARMM36\cite{venable13} & POPC & 690 (NaCl)  & 72 & 2085 & 26  & 0 & 26 & 303  & 73 & 60 & \citenum{charmmPOPC690mMNaClfiles}   \\
   CHARMM36\cite{klauda10}, CHARMM36\cite{venable13}  & POPC & 950 (NaCl)  & 72 & 2168 & 37  & 0 & 37 & 303  & 80 & 60 &\citenum{charmmPOPC950mMNaClfiles}  \\
@@ -518,13 +520,15 @@ A careful analysis with current lipid models is performed in the next section.
   CHARMM36\cite{klauda10}, Yoo\cite{yoo16}  & DPPC & 430 (CaCl$_2$)  & 128 & 7760 & 0 & 60  & 120 & 323  & 200 & 170 & -  \\
   CHARMM36\cite{klauda10}, Yoo\cite{yoo16}  & DPPC & 886 (CaCl$_2$)  & 128 & 7520 & 0 & 120 & 240 & 323  & 200 & 170 & -  \\
   \hline
-  MacRog\cite{maciejewski14}  & POPC & 0 & 288 & 14400 & 0 & 0 & 0 & 310 & 90&40  &~\citenum{macrogdehydFILES}  \\
+  MacRog\cite{maciejewski14}  & POPC & 0 & 288 & 14400 & 0 & 0 & 0 & 310 & 90 & 40  &~\citenum{macrogdehydFILES}  \\  
+  MacRog\cite{maciejewski14}  & POPC & 0 & 128 & 6400 & 0 & 0 & 0 & 310 & 400& 200 &~\citenum{macrogCHOLfiles}  \\ % Matti's 0CHL simu (doi: 10.5281/zenodo.13877)
   MacRog\cite{maciejewski14}, OPLS\cite{aqvist90}  & POPC & 100 (NaCl) & 288 & 14554 & 27 & 0 & 27 & 310 & 90&50  & \citenum{macrogIONfiles} \\
   MacRog\cite{maciejewski14}, OPLS\cite{aqvist90}  & POPC &  210 (NaCl) & 288 & 14500 & 54 & 0 & 54 & 310 & 90&50  &\citenum{macrogIONfiles}  \\
   MacRog\cite{maciejewski14}, OPLS\cite{aqvist90}  & POPC &   310 (NaCl) & 288 & 14446 & 81 & 0 & 81 & 310 & 90&50  & \citenum{macrogIONfiles} \\
   MacRog\cite{maciejewski14}, OPLS\cite{aqvist90}  & POPC &   420 (NaCl) & 288 & 14392 & 108 & 0 & 108 & 310 & 90& 50  & \citenum{macrogIONfiles}  \\
 \end{tabular}
-\end{sidewaystable*} 
+%\end{sidewaystable*} 
+\end{table*}
 
 \begin{sidewaystable*}[!p]
 \centering


### PR DESCRIPTION
Listed the salt-free C36 and MacRog trajectories I have used in my analysis.
